### PR TITLE
Relax AsciiMath constraint and allow 2.0

### DIFF
--- a/jekyll-asciimath.gemspec
+++ b/jekyll-asciimath.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r!^(test|spec|features)/!) }
 
   s.add_runtime_dependency 'jekyll', '~> 4.0'
-  s.add_runtime_dependency 'asciimath', '~> 1.0.9'
+  s.add_runtime_dependency 'asciimath', '>= 1.0.9', '< 3'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rubocop', '~> 0.50'
 


### PR DESCRIPTION
Though it is a major version bump, there are no breaking changes to API. Instead, new version is more about feature parity with JavaScript implementation, it also brings some important bugfixes.

- See discussion in https://github.com/riboseinc/jekyll-asciimath/issues/2
- See AsciiMath [CHANGELOG](https://github.com/asciidoctor/asciimath/blob/master/CHANGELOG.adoc#200)